### PR TITLE
saebom

### DIFF
--- a/src/main/java/com/umc/StudyFlexBE/controller/StudyController.java
+++ b/src/main/java/com/umc/StudyFlexBE/controller/StudyController.java
@@ -31,5 +31,12 @@ public class StudyController {
         List<Study> openStudies = studyService.getOpenStudies();
         return ResponseEntity.ok(openStudies);
     }
+    @GetMapping("/ranking")
+    public ResponseEntity<List<Study>> getStudyRanking() {
+        List<Study> rankedStudies = studyService.getRankedStudies();
+        return ResponseEntity.ok(rankedStudies);
+    }
+
+
 
 }

--- a/src/main/java/com/umc/StudyFlexBE/entity/Study.java
+++ b/src/main/java/com/umc/StudyFlexBE/entity/Study.java
@@ -54,5 +54,19 @@ public class Study {
     @Column(name = "study_hits")
     private BigInteger hits;
 
+    @Column(name = "total_progress_rate")
+    private Double totalProgressRate;
+
+    @Transient
+    private Double rankScore;
+
+    public void setRankScore(Double rankScore) {
+        this.rankScore = rankScore;
+    }
+    public Double getRankScore() {
+        return rankScore; }
+
+
+
 }
 

--- a/src/main/java/com/umc/StudyFlexBE/entity/StudyNotice.java
+++ b/src/main/java/com/umc/StudyFlexBE/entity/StudyNotice.java
@@ -1,0 +1,32 @@
+package com.umc.StudyFlexBE.entity;
+
+import jakarta.persistence.*;
+import org.springframework.data.annotation.Id;
+
+import java.time.LocalDateTime;
+
+public class StudyNotice {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "title", length = 15)
+    private String title;
+
+    @Column(name = "content", length = 1000)
+    private String content;
+
+    @Column(name = "created_at")
+    private LocalDateTime createdAt;
+
+    @Column(name = "updated_at")
+    private LocalDateTime updatedAt;
+
+    @Column(name = "view")
+    private int view;
+
+    @ManyToOne
+    @JoinColumn(name = "study_id")
+    private Study study;
+
+}

--- a/src/main/java/com/umc/StudyFlexBE/repository/StudyNoticeRepository.java
+++ b/src/main/java/com/umc/StudyFlexBE/repository/StudyNoticeRepository.java
@@ -1,0 +1,12 @@
+package com.umc.StudyFlexBE.repository;
+
+import com.umc.StudyFlexBE.entity.Study;
+import com.umc.StudyFlexBE.entity.StudyNotice;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface StudyNoticeRepository extends JpaRepository<StudyNotice, Long> {
+    int countByStudy(Study study);
+
+}

--- a/src/main/java/com/umc/StudyFlexBE/service/StudyService.java
+++ b/src/main/java/com/umc/StudyFlexBE/service/StudyService.java
@@ -1,6 +1,7 @@
 package com.umc.StudyFlexBE.service;
 
 import com.umc.StudyFlexBE.entity.Study;
+import com.umc.StudyFlexBE.repository.StudyNoticeRepository;
 import com.umc.StudyFlexBE.repository.StudyRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Service;
@@ -12,10 +13,13 @@ import java.util.stream.Collectors;
 public class StudyService {
 
     private final StudyRepository studyRepository;
+    private final StudyNoticeRepository studyNoticeRepository;
 
     @Autowired
-    public StudyService(StudyRepository studyRepository) {
+    public StudyService(StudyRepository studyRepository, StudyNoticeRepository studyNoticeRepository) {
+
         this.studyRepository = studyRepository;
+        this.studyNoticeRepository =studyNoticeRepository;
     }
 
     public List<Study> getLatestStudies() {
@@ -25,5 +29,20 @@ public class StudyService {
         return studyRepository.findByStatus("모집중"); // 또는 StudyStatus.모집중, enum 사용시
     }
 
-
+    public List<Study> getRankedStudies() {
+        List<Study> studies = studyRepository.findAll();
+        studies.forEach(this::calculateRankScore);
+        return studies.stream()
+                .sorted((s1, s2) -> Double.compare(s2.getRankScore(), s1.getRankScore()))
+                .limit(3)
+                .collect(Collectors.toList());
     }
+
+    private void calculateRankScore(Study study) {
+        int noticeCount = studyNoticeRepository.countByStudy(study);
+        double rankScore = noticeCount
+                + study.getCurrentMembers()
+                + (study.getTotalProgressRate() * 0.1);
+        study.setRankScore(rankScore);
+    }
+}


### PR DESCRIPTION
메인페이지 랭킹 기능 추가해두었습니다. 

랭킹 순위 기준은 
Sum = a + b + d*0.1

합계 = 등록된 공지사항 수 + 참여인원 수 + 진도율*0.1 입니다!
-> PM님과 상의하여서 조회수는 합계에서 제외하기로 했습니다! 

진도율이 0.75 이런 식으로 나올까봐 *10을 할려고 했었는데 

API 명세서를 보니 스터디 인원 및 진도 퍼센트 조회에서 "total_progress_rate": 75으로 되어 있길래 

*0.1로 계산하였습니다.

랭킹 기능을 위해서 스터디공지사항 엔티티, 스터디공지사항 레포지토리를 만들어두었습니다.
erd랑 명세서 참고해서 만들어두긴 했는데 
창민님 파트랑 겹칠 것 같아요..!  랭킹 기능 할려고 만들어둔 거라서 이미 만드신 거랑 겹치면 지우거나 수정하도록 하겠습니다!!

다른 수정사항이나 잘못된 코드 보시면 말씀해주시면 최대한 빨리 수정하도록 하겠습니다! 감사합니다. 
